### PR TITLE
#1: Extension Linkedin not working when clicking Message Box from Homepage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,12 @@
     "128": "icons/icons128.png"
   },
   "permissions": ["tabs", "activeTab"],
+  "host_permissions": [
+        "https://www.linkedin.com/*"
+  ],
   "content_scripts": [
     {
-      "matches": ["https://www.linkedin.com/messaging/thread/*"],
+      "matches": ["https://*.linkedin.com/*"],
       "js": ["contentScript.js"]
     }
   ],

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,3 +1,31 @@
+//Use Mutation function to observe DOM change
+const chatBubbleObserver = new MutationObserver((mutations) => {
+    const chatBubbleContent = document.querySelector('.msg-overlay-list-bubble__default-conversation-container');
+    if (chatBubbleContent) {
+        // ChatBubbleContent found, keep watching for messageInputBox
+        const messageInputObserver = new MutationObserver((mutations) => {
+            const messageInput = document.querySelector('.msg-form__contenteditable[contenteditable="true"]');
+            if (messageInput) {
+                // messageInput found, create and append the SVG icon
+                createSvgInMessageInputBox();
+                messageInputObserver.disconnect();
+            }
+        });
+        messageInputObserver.observe(chatBubbleContent, {
+            childList: true,
+            subtree: true
+        });
+        chatBubbleObserver.disconnect();
+    }
+});
+chatBubbleObserver.observe(document.body, {
+    childList: true,
+    subtree: true
+});
+
+
+
+
 function createSvgInMessageInputBox(): void {
     const existingIcon: Element | null = document.querySelector('#my-custom-icon');
     if (existingIcon) {


### PR DESCRIPTION
The issue involves two main problems.

First, the core problem was that the extension couldn’t recognize or interact with LinkedIn’s chat bubble class on the homepage. Since LinkedIn’s chat bubble elements load dynamically, the relevant classes only appear when the chat is opened. Because of this, the extension couldn't detect or access the (.msg-form__contenteditable) class, which caused it to fail. To resolve this, I implemented a MutationObserver (chatBubbleObserver) that monitors document.body for changes. When it detects the LinkedIn chat container class (.msg-overlay-list-bubble__default-conversation-container), it stops observing to avoid performance issues. After that, a second MutationObserver (messageInputObserver) watches within chatBubbleContent for the message input (.msg-form__contenteditable[contenteditable="true"]) class. When the input is found, it calls createSvgInMessageInputBox() to insert an SVG icon and then stops observing.

The second problem was related to the configuration in manifest.json. The content_script was only set to work on LinkedIn’s Message page, missing the homepage entirely. To fix this, I modified the content_script path in manifest.json to https://*.linkedin.com/*, allowing the extension to work on both the Message page and the Homepage. This ensures that the extension now functions correctly across the LinkedIn platform.

I only made changes to the src folder and the manifest.json file. You should be able to successfully rebuild the project because the manifest.json file has been updated. I tested rebuilding the project after making these changes, and it worked well.

Please review the changes and let me know if any modifications are required.

Thank youÃ